### PR TITLE
Add basic Jekyll site

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,26 @@ You can customize the email template by creating `templates/newsletter.html`. If
 
    The latest articles are loaded and emailed using Mailchimp.
 
+3. **Build the Jekyll site**
+
+   First copy the fetched articles into the Jekyll site's `_posts/` folder. Use
+   the helper script or create symlinks:
+
+   ```bash
+   # copy files
+   ./scripts/sync_articles_to_jekyll.sh
+   # or create symlinks instead of copies
+   ./scripts/sync_articles_to_jekyll.sh --link
+   ```
+
+   Then build the static site:
+
+   ```bash
+   jekyll build -s jekyll -d jekyll/_site
+   ```
+
+   The generated site will be available under `jekyll/_site/`.
+
 ## Roadmap
 
 The repository currently focuses on fetching articles and sending newsletters. Future improvements may include:

--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -1,0 +1,2 @@
+title: Ukraine Impact
+

--- a/jekyll/_layouts/default.html
+++ b/jekyll/_layouts/default.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>{{ page.title }}</title>
+</head>
+<body>
+  {{ content }}
+</body>
+</html>

--- a/jekyll/index.md
+++ b/jekyll/index.md
@@ -1,0 +1,12 @@
+---
+layout: default
+title: Home
+---
+
+# Articles
+
+<ul>
+{% for post in site.posts %}
+  <li><a href="{{ post.url }}">{{ post.title }}</a> - {{ post.date | date: "%Y-%m-%d" }}</li>
+{% endfor %}
+</ul>

--- a/scripts/sync_articles_to_jekyll.sh
+++ b/scripts/sync_articles_to_jekyll.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Copy or symlink articles from _articles/ to jekyll/_posts/
+# Usage: ./scripts/sync_articles_to_jekyll.sh [--link]
+# Without --link, files are copied. With --link, symlinks are created.
+set -euo pipefail
+
+SOURCE_DIR="_articles"
+TARGET_DIR="jekyll/_posts"
+mkdir -p "$TARGET_DIR"
+
+for f in "$SOURCE_DIR"/*.md; do
+    [ -e "$f" ] || continue
+    filename="$(basename "$f")"
+    dest="$TARGET_DIR/$filename"
+    if [ "${1-}" = "--link" ]; then
+        ln -sf "../../$f" "$dest"
+    else
+        cp "$f" "$dest"
+    fi
+    echo "Synced $f -> $dest"
+done


### PR DESCRIPTION
## Summary
- add minimal Jekyll site in `jekyll/`
- add helper script to sync articles to Jekyll posts
- document building the Jekyll site

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `shellcheck scripts/sync_articles_to_jekyll.sh` *(fails: command not found)*
- `jekyll --version` *(fails: command not found)*