### PR TITLE
Add GitHub Actions newsletter workflow

### DIFF
--- a/.github/workflows/newsletter.yml
+++ b/.github/workflows/newsletter.yml
@@ -1,0 +1,34 @@
+name: Weekly Newsletter
+
+on:
+  schedule:
+    - cron: '0 8 * * 1'
+  workflow_dispatch:
+
+jobs:
+  send:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Fetch RSS feeds
+        env:
+          RSS_FEED_URLS: ${{ secrets.RSS_FEED_URLS }}
+        run: python scripts/fetch_rss_feeds.py
+      - name: Send newsletter
+        env:
+          MAILCHIMP_API_KEY: ${{ secrets.MAILCHIMP_API_KEY }}
+          MAILCHIMP_SERVER_PREFIX: ${{ secrets.MAILCHIMP_SERVER_PREFIX }}
+          MAILCHIMP_LIST_ID: ${{ secrets.MAILCHIMP_LIST_ID }}
+          EMAIL_FROM: ${{ secrets.EMAIL_FROM }}
+          EMAIL_FROM_NAME: ${{ secrets.EMAIL_FROM_NAME }}
+          RSS_FEED_URLS: ${{ secrets.RSS_FEED_URLS }}
+        run: python scripts/send_newsletter.py

--- a/README.md
+++ b/README.md
@@ -67,6 +67,17 @@ The repository currently focuses on fetching articles and sending newsletters. F
 - A Jekyll website to publish the collected articles.
 - A GitHub Actions workflow to automate fetching and mailing.
 
+## Automation
+
+A scheduled GitHub Actions workflow automatically fetches articles and sends the newsletter. Configure these repository secrets so the workflow can run:
+- `RSS_FEED_URLS`
+- `MAILCHIMP_API_KEY`
+- `MAILCHIMP_SERVER_PREFIX`
+- `MAILCHIMP_LIST_ID`
+- `EMAIL_FROM`
+- `EMAIL_FROM_NAME`
+
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- automate weekly newsletter via GitHub Actions
- document workflow secrets in README

## Testing
- `python -m py_compile scripts/fetch_rss_feeds.py scripts/send_newsletter.py`