### PR TITLE
Add date-based filenames to Jekyll sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ You can customize the email template by creating `templates/newsletter.html`. If
 3. **Build the Jekyll site**
 
    First copy the fetched articles into the Jekyll site's `_posts/` folder. Use
-   the helper script or create symlinks:
+   the helper script or create symlinks. The script automatically prefixes each
+   article filename with the date from its front matter so that Jekyll can
+   process it as a dated post:
 
    ```bash
    # copy files

--- a/scripts/sync_articles_to_jekyll.sh
+++ b/scripts/sync_articles_to_jekyll.sh
@@ -10,8 +10,15 @@ mkdir -p "$TARGET_DIR"
 
 for f in "$SOURCE_DIR"/*.md; do
     [ -e "$f" ] || continue
-    filename="$(basename "$f")"
-    dest="$TARGET_DIR/$filename"
+    filename="$(basename "$f" .md)"
+    # extract date from front matter and format as YYYY-MM-DD
+    date_line=$(awk -F': ' '/^date:/ {print $2; exit}' "$f")
+    if [ -n "$date_line" ]; then
+        date_prefix=$(echo "$date_line" | cut -c1-10)
+    else
+        date_prefix=$(date +%Y-%m-%d)
+    fi
+    dest="$TARGET_DIR/${date_prefix}-${filename}.md"
     if [ "${1-}" = "--link" ]; then
         ln -sf "../../$f" "$dest"
     else


### PR DESCRIPTION
## Summary
- prefix synced article filenames with the date from YAML front matter
- document the automatic date prefix in README

## Testing
- `bash scripts/sync_articles_to_jekyll.sh` (with and without sample files)